### PR TITLE
Fix Aqua tests and Project files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,6 @@ uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.1.0"
 
-[deps]
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-
 [compat]
 Aqua = "0.8.9"
 Test = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,0 @@
-[deps]
-FusionTensors = "e16ca583-1f51-4df0-8e12-57d32947d33e"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,7 +4,7 @@ using Aqua: Aqua
 using Test: @testset
 
 @testset "Code quality (Aqua.jl)" begin
-    Aqua.test_all(FusionTensors)
+  Aqua.test_all(FusionTensors)
 end
 
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -4,16 +4,7 @@ using Aqua: Aqua
 using Test: @testset
 
 @testset "Code quality (Aqua.jl)" begin
-  Aqua.test_ambiguities([FusionTensors])
-  Aqua.test_unbound_args(FusionTensors)
-  Aqua.test_undefined_exports(FusionTensors)
-  Aqua.test_project_extras(FusionTensors)
-  Aqua.test_deps_compat(FusionTensors)
-  Aqua.test_piracies(FusionTensors)
-  Aqua.test_persistent_tasks(FusionTensors)
-
-  # TODO fix test_stale_deps
-  # TODO replace with Aqua.test_all
-  # Aqua.test_stale_deps(FusionTensors)
+    Aqua.test_all(FusionTensors)
 end
+
 end


### PR DESCRIPTION
This resolves the complaints of Aqua about stale dependencies:

- remove the test/Project.toml since these dependencies are defined in the main Project.toml
- remove Aqua from the [deps], since it is only a test dependency and should thus only be in [extras]