### PR TITLE
Define `real` and `imag`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FusionTensors"
 uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/fusiontensor/base_interface.jl
+++ b/src/fusiontensor/base_interface.jl
@@ -73,13 +73,19 @@ function Base.getindex(ft::FusionTensor, f1::SectorFusionTree, f2::SectorFusionT
   return reshape(charge_matrix, charge_block_size(ft, f1, f2))
 end
 
+Base.imag(ft::FusionTensor{<:Real}) = ft   # same object
+Base.imag(ft::FusionTensor) = set_data_matrix(ft, imag(data_matrix(ft)))
+
+Base.permutedims(ft::FusionTensor, args...) = fusiontensor_permutedims(ft, args...)
+
+Base.real(ft::FusionTensor{<:Real}) = ft   # same object
+Base.real(ft::FusionTensor) = set_data_matrix(ft, real(data_matrix(ft)))
+
 function Base.setindex!(
   ft::FusionTensor, a::AbstractArray, f1::SectorFusionTree, f2::SectorFusionTree
 )
   return view(ft, f1, f2) .= a
 end
-
-Base.permutedims(ft::FusionTensor, args...) = fusiontensor_permutedims(ft, args...)
 
 function Base.similar(ft::FusionTensor, T::Type)
   # reuse trees_block_mapping

--- a/src/fusiontensor/base_interface.jl
+++ b/src/fusiontensor/base_interface.jl
@@ -73,7 +73,6 @@ function Base.getindex(ft::FusionTensor, f1::SectorFusionTree, f2::SectorFusionT
   return reshape(charge_matrix, charge_block_size(ft, f1, f2))
 end
 
-Base.imag(ft::FusionTensor{<:Real}) = ft   # same object
 Base.imag(ft::FusionTensor) = set_data_matrix(ft, imag(data_matrix(ft)))
 
 Base.permutedims(ft::FusionTensor, args...) = fusiontensor_permutedims(ft, args...)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -248,7 +248,7 @@ end
 
   @test conj(ft3) === ft3  # same object
   @test real(ft3) === ft3
-  @test norm(imag(ft3)) == 0.0
+  @test all(==(0.0), data_matrix(imag(ft3)))
 
   @test conj(ft5) isa FusionTensor{ComplexF64,4}
   @test real(ft5) isa FusionTensor{Float64,4}

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -28,7 +28,7 @@ using GradedArrays:
   space_isequal
 using TensorAlgebra: tuplemortar
 using TensorProducts: tensor_product
-using LinearAlgebra: LinearAlgebra
+using LinearAlgebra: LinearAlgebra, norm
 using Random: Random
 
 include("setup.jl")
@@ -184,104 +184,6 @@ end
   @test sector_type(ft3) === TrivialSector
 end
 
-@testset "Base operations" begin
-  g1 = gradedrange([U1(0) => 1, U1(1) => 2, U1(2) => 3])
-  g2 = gradedrange([U1(0) => 2, U1(1) => 2, U1(3) => 1])
-  g3 = gradedrange([U1(-1) => 1, U1(0) => 2, U1(1) => 1])
-  g4 = gradedrange([U1(-1) => 1, U1(0) => 1, U1(1) => 1])
-  ft3 = FusionTensor{Float64}(undef, (g1, g2), (g3, g4))
-  @test isnothing(check_sanity(ft3))
-
-  ft4 = +ft3
-  @test ft4 === ft3  # same object
-
-  ft4 = -ft3
-  @test isnothing(check_sanity(ft4))
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-
-  ft4 = ft3 + ft3
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-
-  ft4 = ft3 - ft3
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-
-  ft4 = 2 * ft3
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-  @test eltype(ft4) == Float64
-
-  ft4 = 2.0 * ft3
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-  @test eltype(ft4) == Float64
-
-  ft4 = ft3 / 2.0
-  @test codomain_axes(ft4) === codomain_axes(ft3)
-  @test domain_axes(ft4) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-  @test eltype(ft4) == Float64
-
-  ft5 = (1.0 + 2.0im) * ft3
-  @test codomain_axes(ft5) === codomain_axes(ft3)
-  @test domain_axes(ft5) === domain_axes(ft3)
-  @test space_isequal(codomain_axis(ft5), codomain_axis(ft3))
-  @test space_isequal(domain_axis(ft5), domain_axis(ft3))
-  @test isnothing(check_sanity(ft4))
-  @test eltype(ft5) == ComplexF64
-
-  @test conj(ft3) === ft3  # same object
-  @test real(ft3) === ft3
-  @test all(==(0.0), data_matrix(imag(ft3)))
-
-  @test conj(ft5) isa FusionTensor{ComplexF64,4}
-  @test real(ft5) isa FusionTensor{Float64,4}
-  @test imag(ft3) isa FusionTensor{Float64,4}
-  @test conj(ft5) ≈ (1.0 - 2.0im) * ft3
-  @test real(ft5) ≈ ft3
-  @test imag(ft3) ≈ 2ft3
-
-  ft6 = conj(ft5)
-  @test ft6 !== ft5  # different object
-  @test isnothing(check_sanity(ft6))
-  @test codomain_axes(ft6) === codomain_axes(ft5)
-  @test domain_axes(ft6) === domain_axes(ft5)
-  @test space_isequal(codomain_axis(ft6), codomain_axis(ft5))
-  @test space_isequal(domain_axis(ft6), domain_axis(ft5))
-  @test eltype(ft6) == ComplexF64
-
-  ad = adjoint(ft3)
-  @test ad isa FusionTensor
-  @test ndims_codomain(ad) == 2
-  @test ndims_domain(ad) == 2
-  @test space_isequal(dual(g1), domain_axes(ad)[1])
-  @test space_isequal(dual(g2), domain_axes(ad)[2])
-  @test space_isequal(dual(g3), codomain_axes(ad)[1])
-  @test space_isequal(dual(g4), codomain_axes(ad)[2])
-  @test isnothing(check_sanity(ad))
-
-  ft7 = FusionTensor{Float64}(undef, (g1,), (g2, g3, g4))
-  @test_throws ArgumentError ft7 + ft3
-  @test_throws ArgumentError ft7 - ft3
-  @test_throws ArgumentError ft7 * ft3
-end
-
 @testset "specific constructors" begin
   g1 = gradedrange([U1(0) => 1, U1(1) => 2, U1(2) => 3])
   g2 = gradedrange([U1(0) => 2, U1(1) => 2, U1(3) => 1])
@@ -319,6 +221,114 @@ end
   end
 
   @test FusionTensor{ComplexF64}(LinearAlgebra.I, (g1, g2)) isa FusionTensor{ComplexF64,4}
+end
+
+@testset "Base operations" begin
+  g1 = gradedrange([U1(0) => 1, U1(1) => 2, U1(2) => 3])
+  g2 = gradedrange([U1(0) => 2, U1(1) => 2, U1(3) => 1])
+  g3 = gradedrange([U1(-1) => 1, U1(0) => 2, U1(1) => 1])
+  g4 = gradedrange([U1(-1) => 1, U1(0) => 1, U1(1) => 1])
+  ft3 = randn(FusionTensorAxes((g1, g2), (g3, g4)))
+  @test ft3 isa FusionTensor{Float64,4}
+  @test norm(ft3) ≉ 0
+  @test isnothing(check_sanity(ft3))
+
+  ft4 = +ft3
+  @test ft4 === ft3  # same object
+
+  ft4 = -ft3
+  @test isnothing(check_sanity(ft4))
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test norm(ft4) ≈ norm(ft3)
+  @test norm(ft4 + ft3) ≈ 0.0
+
+  ft4 = ft3 + ft3
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test norm(ft4) ≈ 2norm(ft3)
+
+  ft4 = ft3 - ft3
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test norm(ft4) ≈ 0.0
+
+  ft4 = 2 * ft3
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test eltype(ft4) == Float64
+  @test norm(ft4) ≈ 2norm(ft3)
+
+  ft4 = 2.0 * ft3
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test eltype(ft4) == Float64
+
+  ft4 = ft3 / 2.0
+  @test codomain_axes(ft4) === codomain_axes(ft3)
+  @test domain_axes(ft4) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft4), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft4), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test eltype(ft4) == Float64
+  @test norm(ft4) ≈ norm(ft3) / 2.0
+
+  ft5 = (1.0 + 2.0im) * ft3
+  @test codomain_axes(ft5) === codomain_axes(ft3)
+  @test domain_axes(ft5) === domain_axes(ft3)
+  @test space_isequal(codomain_axis(ft5), codomain_axis(ft3))
+  @test space_isequal(domain_axis(ft5), domain_axis(ft3))
+  @test isnothing(check_sanity(ft4))
+  @test eltype(ft5) == ComplexF64
+  @test norm(ft5) ≈ √5 * norm(ft3)
+
+  @test conj(ft3) === ft3  # same object
+  @test real(ft3) === ft3
+  @test norm(imag(ft3)) == 0
+
+  @test conj(ft5) isa FusionTensor{ComplexF64,4}
+  @test real(ft5) isa FusionTensor{Float64,4}
+  @test imag(ft3) isa FusionTensor{Float64,4}
+  @test conj(ft5) ≈ (1.0 - 2.0im) * ft3
+  @test real(ft5) ≈ ft3
+  @test imag(ft5) ≈ 2ft3
+
+  ft6 = conj(ft5)
+  @test ft6 !== ft5  # different object
+  @test isnothing(check_sanity(ft6))
+  @test codomain_axes(ft6) === codomain_axes(ft5)
+  @test domain_axes(ft6) === domain_axes(ft5)
+  @test space_isequal(codomain_axis(ft6), codomain_axis(ft5))
+  @test space_isequal(domain_axis(ft6), domain_axis(ft5))
+  @test eltype(ft6) == ComplexF64
+  @test ft6 + ft5 ≈ 2 * real(ft5)
+
+  ad = adjoint(ft3)
+  @test ad isa FusionTensor
+  @test ndims_codomain(ad) == 2
+  @test ndims_domain(ad) == 2
+  @test space_isequal(dual(g1), domain_axes(ad)[1])
+  @test space_isequal(dual(g2), domain_axes(ad)[2])
+  @test space_isequal(dual(g3), codomain_axes(ad)[1])
+  @test space_isequal(dual(g4), codomain_axes(ad)[2])
+  @test isnothing(check_sanity(ad))
+
+  ft7 = FusionTensor{Float64}(undef, (g1,), (g2, g3, g4))
+  @test_throws ArgumentError ft7 + ft3
+  @test_throws ArgumentError ft7 - ft3
+  @test_throws ArgumentError ft7 * ft3
 end
 
 @testset "missing SectorProduct" begin

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -238,7 +238,7 @@ end
   @test isnothing(check_sanity(ft4))
   @test eltype(ft4) == Float64
 
-  ft5 = 2.0im * ft3
+  ft5 = (1.0 + 2.0im) * ft3
   @test codomain_axes(ft5) === codomain_axes(ft3)
   @test domain_axes(ft5) === domain_axes(ft3)
   @test space_isequal(codomain_axis(ft5), codomain_axis(ft3))
@@ -246,8 +246,16 @@ end
   @test isnothing(check_sanity(ft4))
   @test eltype(ft5) == ComplexF64
 
-  ft4 = conj(ft3)
-  @test ft4 === ft3  # same object
+  @test conj(ft3) === ft3  # same object
+  @test real(ft3) === ft3
+  @test norm(imag(ft3)) == 0.0
+
+  @test conj(ft5) isa FusionTensor{ComplexF64,4}
+  @test real(ft5) isa FusionTensor{Float64,4}
+  @test imag(ft3) isa FusionTensor{Float64,4}
+  @test conj(ft5) ≈ (1.0 - 2.0im) * ft3
+  @test real(ft5) ≈ ft3
+  @test imag(ft3) ≈ 2ft3
 
   ft6 = conj(ft5)
   @test ft6 !== ft5  # different object


### PR DESCRIPTION
This PR defines `real` and `imag` for a `FusionTensor`.

The default implementation relies on `Broadcast` and errors on some axis convention.