### PR TITLE
define `LinearAlgebra.normalize`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FusionTensors"
 uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.5.9"
+version = "0.5.10"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/fusiontensor/linear_algebra_interface.jl
+++ b/src/fusiontensor/linear_algebra_interface.jl
@@ -42,25 +42,17 @@ function LinearAlgebra.norm(ft::FusionTensor)
   return sqrt(n2)
 end
 
+LinearAlgebra.normalize(ft::FusionTensor) = set_data_matrix(ft, data_matrix(ft) / norm(ft))
+
+function LinearAlgebra.normalize!(ft::FusionTensor)
+  data_matrix(ft) ./= norm(ft)
+  return ft
+end
+
 function LinearAlgebra.tr(ft::FusionTensor)
   m = data_matrix(ft)
   row_sectors = sectors(codomain_axis(ft))
   return sum(eachblockstoredindex(m); init=zero(eltype(ft))) do b
     return quantum_dimension(row_sectors[Int(first(Tuple(b)))]) * tr(m[b])
   end
-end
-
-function LinearAlgebra.qr(ft::FusionTensor)
-  qmat, rmat = block_qr(data_matrix(ft))
-  qtens = FusionTensor(qmat, codomain_axes(ft), (axes(qmat, 2),))
-  rtens = FusionTensor(rmat, (axes(rmat, 1),), domain_axes(ft))
-  return qtens, rtens
-end
-
-function LinearAlgebra.svd(ft::FusionTensor)
-  umat, s, vmat = block_svd(data_matrix(ft))
-  utens = FusionTensor(umat, codomain_axes(ft), (axes(umat, 2),))
-  stens = FusionTensor(s, (axes(umat, 1),), (axes(vmat, 2),))
-  vtens = FusionTensor(vmat, (axes(vmat, 1),), domain_axes(ft))
-  return utens, stens, vtens
 end

--- a/test/test_linear_algebra.jl
+++ b/test/test_linear_algebra.jl
@@ -27,5 +27,10 @@ include("setup.jl")
     @test isnothing(check_sanity(ft))
     @test norm(ft) ≈ √3 / 2
     @test isapprox(tr(ft), 0; atol=eps(Float64))
+
+    @test norm(normalize(ft)) ≈ 1.0
+    @test norm(ft) ≈ √3 / 2  # unaffected by normalize
+    normalize!(ft)
+    @test norm(ft) ≈ 1.0
   end
 end

--- a/test/test_linear_algebra.jl
+++ b/test/test_linear_algebra.jl
@@ -28,8 +28,10 @@ include("setup.jl")
     @test norm(ft) ≈ √3 / 2
     @test isapprox(tr(ft), 0; atol=eps(Float64))
 
-    @test norm(normalize(ft)) ≈ 1.0
+    ft2 = normalize(ft)
+    @test norm(ft2) ≈ 1.0
     @test norm(ft) ≈ √3 / 2  # unaffected by normalize
+    @test ft ≈ √3 / 2 * ft2
     normalize!(ft)
     @test norm(ft) ≈ 1.0
   end


### PR DESCRIPTION
This PR defines `LinearAlgebra.normalize` and `LinearAlgebra.normalize!` for a `FusionTensor`. Also removes some filled code.