### PR TITLE
CompatHelper: bump compat for TensorAlgebra to 0.9, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FusionTensors"
 uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
-version = "0.5.36"
+version = "0.5.37"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -31,7 +31,7 @@ LRUCache = "1.6"
 LinearAlgebra = "1.10"
 Random = "1.10"
 Strided = "2.3"
-TensorAlgebra = "0.6.4"
+TensorAlgebra = "0.6.4, 0.9"
 TensorKitSectors = "0.1, 0.2"
 TypeParameterAccessors = "0.4"
 WignerSymbols = "2"


### PR DESCRIPTION
This pull request changes the compat entry for the `TensorAlgebra` package from `0.6.4` to `0.6.4, 0.9`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.