### PR TITLE
CompatHelper: bump compat for GradedArrays to 0.8, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FusionTensors"
 uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
-version = "0.5.36"
+version = "0.5.37"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -25,7 +25,7 @@ WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
 Accessors = "0.1.42"
 BlockArrays = "1.7"
 BlockSparseArrays = "0.10"
-GradedArrays = "0.5.2"
+GradedArrays = "0.5.2, 0.8"
 HalfIntegers = "1.6"
 LRUCache = "1.6"
 LinearAlgebra = "1.10"


### PR DESCRIPTION
This pull request changes the compat entry for the `GradedArrays` package from `0.5.2` to `0.5.2, 0.8`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.