### PR TITLE
CompatHelper: bump compat for TensorKitSectors to 0.3, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FusionTensors"
 uuid = "e16ca583-1f51-4df0-8e12-57d32947d33e"
-version = "0.5.36"
+version = "0.5.37"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -32,7 +32,7 @@ LinearAlgebra = "1.10"
 Random = "1.10"
 Strided = "2.3"
 TensorAlgebra = "0.6.4"
-TensorKitSectors = "0.1, 0.2"
+TensorKitSectors = "0.1, 0.2, 0.3"
 TypeParameterAccessors = "0.4"
 WignerSymbols = "2"
 julia = "1.10"


### PR DESCRIPTION
This pull request changes the compat entry for the `TensorKitSectors` package from `0.1, 0.2` to `0.1, 0.2, 0.3`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.